### PR TITLE
CLOUD-2528: Appliance: VM Deployment Script: KeyError in ova_deployer

### DIFF
--- a/ova_deployer.py
+++ b/ova_deployer.py
@@ -106,6 +106,7 @@ if __name__ == '__main__':
             'verbose': ARGS.verbose,
             'thin_disk': ARGS.thin,
             'insecure': ARGS.insecure,
+            'folder': ARGS.folder,
         }) + [ARGS.image, ARGS.locator],
         check=True
     )


### PR DESCRIPTION
One-liner fix for trace:

```
VMware ovftool 4.4.0 (build-16803747)
Ignoring unknown property 'network'
Ignoring empty property 'httpProxy'
Ignoring empty property 'httpsProxy'
Traceback (most recent call last):
  File "/Users/bouff/IdeaProjects/ova-deployer/ova_deployer.py", line 102, in <module>
    __generate_ovf_args(OVF_TOOL, APPLIANCE_CONFIG, {
  File "/Users/bouff/IdeaProjects/ova-deployer/ova_deployer.py", line 88, in __generate_ovf_args
    if settings['folder']:
KeyError: 'folder'
```